### PR TITLE
Kml for android and pc

### DIFF
--- a/app/res/values-fr/strings_export_kml.xml
+++ b/app/res/values-fr/strings_export_kml.xml
@@ -7,6 +7,7 @@
     <string name="export_kml_track_name">Tracé : %s</string>
     <string name="export_kml_linestring_name">Segment : %s</string>
     <string name="export_kml_ride">Parcours</string>
+    <string name="export_kml_point_name">Fin</string>
     <!--  END translatable strings -->
 
 </resources>

--- a/app/res/values/strings_export_kml.xml
+++ b/app/res/values/strings_export_kml.xml
@@ -7,6 +7,7 @@
     <string name="export_kml_track_name">Track: %s</string>
     <string name="export_kml_linestring_name">LineString: %s</string>
     <string name="export_kml_ride">Ride</string>
+    <string name="export_kml_point_name">End</string>
     <!-- END translatable strings -->
 
     <string name="export_kml_name" translatable="false"><![CDATA[<name>%s</name>]]></string>
@@ -50,6 +51,8 @@
 </LineString>
 ]]>
     </string>
+    <string name="export_kml_point_begin" translatable="false"><![CDATA[<Point><coordinates>]]></string>
+    <string name="export_kml_point_end" translatable="false"><![CDATA[</coordinates></Point>]]></string>
     <string name="export_kml_when" translatable="false"><![CDATA[<when>%s</when>]]></string>
     <string name="export_kml_coord" translatable="false"><![CDATA[<gx:coord>%1$s %2$s %3$s</gx:coord>]]></string>
     <string name="export_kml_look_at" translatable="false">

--- a/app/src/org/jraf/android/bikey/backend/export/kml/KmlExporter.java
+++ b/app/src/org/jraf/android/bikey/backend/export/kml/KmlExporter.java
@@ -91,11 +91,15 @@ public class KmlExporter extends Exporter {
 
             // Write out the Placemark for the track.
             c.moveToPosition(-1);
-            writeTrackPlacemark(rideUri, c, out, timestampBegin);
+            writeTrackPlacemark(c, out, timestampBegin);
 
             // Write out the Placemark for the LineString.
             c.moveToPosition(-1);
-            writeLineStringPlacemark(rideUri, c, out, timestampBegin);
+            writeLineStringPlacemark(c, out, timestampBegin);
+
+            // Write out the Placemark for the end Point.
+            c.moveToPosition(-1);
+            writePointPlacemark(rideUri, c, out, timestampBegin);
 
             // Write the KML elements to close the document.
             out.println(getString(R.string.export_kml_folder_end));
@@ -109,7 +113,7 @@ public class KmlExporter extends Exporter {
     /**
      * Write a Placemark which contains a gx:Track element
      */
-    private void writeTrackPlacemark(Uri rideUri, LogCursorWrapper c, PrintWriter out, String timestampBegin) {
+    private void writeTrackPlacemark(LogCursorWrapper c, PrintWriter out, String timestampBegin) {
         Log.d();
         out.println(getString(R.string.export_kml_placemark_begin));
         String trackName = getString(R.string.export_kml_track_name, timestampBegin);
@@ -134,14 +138,13 @@ public class KmlExporter extends Exporter {
         }
 
         out.println(getString(R.string.export_kml_track_end));
-        writeExtendedData(rideUri, out);
         out.println(getString(R.string.export_kml_placemark_end));
     }
 
     /**
      * Write a Placemark which contains a LineString element.
      */
-    private void writeLineStringPlacemark(Uri rideUri, LogCursorWrapper c, PrintWriter out, String timestampBegin) {
+    private void writeLineStringPlacemark(LogCursorWrapper c, PrintWriter out, String timestampBegin) {
         Log.d();
         out.println(getString(R.string.export_kml_placemark_begin));
         String linestringName = getString(R.string.export_kml_linestring_name, timestampBegin);
@@ -156,6 +159,24 @@ public class KmlExporter extends Exporter {
             out.println(longitude + "," + latitude + "," + elevation + " ");
         }
         out.println(getString(R.string.export_kml_linestring_end));
+        out.println(getString(R.string.export_kml_placemark_end));
+    }
+
+    /**
+     * Write a Placemark which contains a Point element corresponding to the last track point.
+     */
+    private void writePointPlacemark(Uri rideUri, LogCursorWrapper c, PrintWriter out, String timestampBegin) {
+        Log.d();
+        out.println(getString(R.string.export_kml_placemark_begin));
+        String pointName = getString(R.string.export_kml_point_name);
+        out.println(getString(R.string.export_kml_name, pointName));
+        out.println(getString(R.string.export_kml_point_begin));
+        c.moveToLast();
+        double latitude = c.getLat();
+        double longitude = c.getLon();
+        double elevation = c.getEle();
+        out.println(longitude + "," + latitude + "," + elevation + " ");
+        out.println(getString(R.string.export_kml_point_end));
         writeExtendedData(rideUri, out);
         out.println(getString(R.string.export_kml_placemark_end));
     }


### PR DESCRIPTION
1. Fix so that the ride appears on both Android and PC Google Earth: now three Placemarks are created, one with a gx:Track, one with a LineString, and one with a single Point.  On Android it will be the LineString and Point which appear.  On PC all three Placemarks will appear.
2. Made the Folder and Placemark names translatable.
3. Added an ExtendedData element to a new PlaceMark containing one Point (the last position of the ride), so that tapping on the this point in GoogleEarth will bring up a popup with stats on the ride.
