### PR TITLE
Update libraries:

### DIFF
--- a/PebbleKit/build.gradle
+++ b/PebbleKit/build.gradle
@@ -23,5 +23,5 @@ android {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:14.0.1'
+    compile 'com.google.guava:guava:20.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ import java.text.SimpleDateFormat
 
 ext.globalProjectName = 'bikey'
 
+// Run './gradlew dependencyUpdates' to see new versions of dependencies
+apply plugin: 'com.github.ben-manes.versions'
+
 buildscript {
     repositories {
         jcenter()
@@ -10,10 +13,9 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
-        classpath 'ca.rmen:lib-french-revolutionary-calendar:1.5.0'
-        classpath 'io.fabric.tools:gradle:1.21.7'
-        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
+        classpath 'ca.rmen:lib-french-revolutionary-calendar:1.5.2'
+        classpath 'io.fabric.tools:gradle:1.22.1'
     }
 }
 
@@ -24,11 +26,36 @@ allprojects {
         maven { url "https://jitpack.io" }
         maven { url 'https://maven.fabric.io/public' }
     }
+    dependencyUpdates.resolutionStrategy = {
+        componentSelection { rules ->
+            rules.all { ComponentSelection selection ->
+                boolean rejected = ['alpha', 'alpha-preview', 'beta', 'rc', 'cr', 'm'].any { qualifier ->
+                    selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
+                }
+                if (rejected) {
+                    selection.reject('Release candidate')
+                }
+            }
+        }
+    }
+    // Force using our version of the support libraries, even for those we don't depend on directly (transitive dependencies)
+    configurations.all {
+        resolutionStrategy {
+            force "com.android.support:appcompat-v7:$supportLibVersion",
+                    "com.android.support:cardview-v7:$supportLibVersion",
+                    "com.android.support:customtabs:$supportLibVersion",
+                    "com.android.support:support-v4:$supportLibVersion",
+                    "com.android.support:support-annotations:$supportLibVersion",
+                    "com.android.support:percent:$supportLibVersion",
+                    "com.android.support:recyclerview-v7:$supportLibVersion"
+        }
+    }
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
 
 // Add a 'release' task that increments the build number
 def releaseTask = tasks.create(name: 'release', group: 'build')
@@ -46,8 +73,6 @@ subprojects {
     }
 }
 
-// Run './gradlew dependencyUpdates' to see new versions of dependencies
-apply plugin: 'com.github.ben-manes.versions'
 
 // Returns the name of the current git branch
 def gitBranch() {
@@ -92,7 +117,8 @@ ext.compileSdkVersion = 24
 ext.targetSdkVersion = 22
 ext.buildToolsVersion = '25.0.2'
 ext.supportLibVersion = '25.3.1'
-ext.playServicesVersion = '9.2.1'
+ext.playServicesVersion = '10.2.1'
+ext.butterknifeVersion = '8.5.1'
 
 // Splash screen
 println """\n

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -27,6 +27,6 @@ dependencies {
     compile "com.google.android.gms:play-services-wearable:${playServicesVersion}"
 
     // Other libs
-    compile 'com.jakewharton:butterknife:8.2.1'
+    compile "com.jakewharton:butterknife:${butterknifeVersion}"
     compile 'com.github.BoD:jraf-android-util:-SNAPSHOT'
 }

--- a/handheld/build.gradle
+++ b/handheld/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
-apply plugin: 'android-apt'
 
 android {
     compileSdkVersion project.compileSdkVersion
@@ -90,13 +89,13 @@ dependencies {
     compile "com.android.support:appcompat-v7:${supportLibVersion}"
     compile "com.google.android.gms:play-services-maps:${playServicesVersion}"
     compile "com.google.android.gms:play-services-drive:${playServicesVersion}"
-    compile 'com.jakewharton:butterknife:8.2.1'
+    compile "com.jakewharton:butterknife:${butterknifeVersion}"
     compile 'fr.nicolaspomepuy.androidwearcrashreport:crashreport-mobile:0.5@aar'
-    compile('com.crashlytics.sdk.android:crashlytics:2.6.0@aar') { transitive = true; }
+    compile('com.crashlytics.sdk.android:crashlytics:2.6.7@aar') { transitive = true; }
     compile 'com.github.BoD:jraf-android-util:-SNAPSHOT'
     compile project(':common')
     compile project(':PebbleKit')
     // Package the wear apk inside this one
     wearApp project(':wear')
-    apt 'com.jakewharton:butterknife-compiler:8.2.1'
+    annotationProcessor "com.jakewharton:butterknife-compiler:${butterknifeVersion}"
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'android-apt'
 
 android {
     compileSdkVersion project.compileSdkVersion
@@ -53,5 +52,5 @@ dependencies {
 
     // Other libs
     compile 'fr.nicolaspomepuy.androidwearcrashreport:crashreport-wear:0.5@aar'
-    apt 'com.jakewharton:butterknife-compiler:8.2.1'
+    annotationProcessor "com.jakewharton:butterknife-compiler:${butterknifeVersion}"
 }


### PR DESCRIPTION
ben-manes: 0.13.0 -> 0.14.0
frc: 1.5.0 -> 1.5.2
fabric: 1.21.7 -> 1.22.1
crashlytics: 2.6.0 -> 2.6.7
gms: 9.2.1 -> 10.2.1
butterknife: 8.2.1 -> 8.5.1
guava: 14.0.1 -> 20.0: Note, 21.0 exists, but requires java 8.

Also:
    * Specify the butterknife version in one place (the root gradle file).
    * Tell ben-manes to exclude alpha/beta/rc builds when checking for new library versions.
    * Force the project to use one version of the support library
    * Use annotationProcessor instead of apt