### PR TITLE
Use retrolambda.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         classpath 'ca.rmen:lib-french-revolutionary-calendar:1.5.2'
         classpath 'io.fabric.tools:gradle:1.22.1'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.4'
+        classpath 'me.tatarka:gradle-retrolambda:3.6.0'
     }
 }
 

--- a/handheld/build.gradle
+++ b/handheld/build.gradle
@@ -1,10 +1,16 @@
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
 apply plugin: 'com.getkeepsafe.dexcount'
+apply plugin: 'me.tatarka.retrolambda'
 
 android {
     compileSdkVersion project.compileSdkVersion
     buildToolsVersion project.buildToolsVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
     defaultConfig {
         applicationId 'org.jraf.android.bikey'

--- a/handheld/proguard-rules.pro
+++ b/handheld/proguard-rules.pro
@@ -14,3 +14,6 @@
 -dontwarn sun.misc.**
 -dontwarn javax.inject.**
 -dontwarn com.google.common.**
+
+# For retrolambda: https://github.com/evant/gradle-retrolambda
+-dontwarn java.lang.invoke.*

--- a/handheld/src/main/java/org/jraf/android/bikey/app/Application.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/Application.java
@@ -37,7 +37,6 @@ import org.jraf.android.util.log.Log;
 
 import com.crashlytics.android.Crashlytics;
 
-import fr.nicolaspomepuy.androidwearcrashreport.mobile.CrashInfo;
 import fr.nicolaspomepuy.androidwearcrashreport.mobile.CrashReport;
 import io.fabric.sdk.android.Fabric;
 
@@ -66,13 +65,10 @@ public class Application extends android.app.Application {
 
             // AndroidWearCrashReport
             try {
-                CrashReport.getInstance(this).setOnCrashListener(new CrashReport.IOnCrashListener() {
-                    @Override
-                    public void onCrashReceived(CrashInfo crashInfo) {
-                        Exception exception = new Exception("Crash on the wearable app " + crashInfo.getManufacturer() + "/" + crashInfo.getModel() + "/" +
-                                crashInfo.getProduct() + "/" + crashInfo.getFingerprint(), crashInfo.getThrowable());
-                        Crashlytics.logException(exception);
-                    }
+                CrashReport.getInstance(this).setOnCrashListener(crashInfo -> {
+                    Exception exception = new Exception("Crash on the wearable app " + crashInfo.getManufacturer() + "/" + crashInfo.getModel() + "/" +
+                            crashInfo.getProduct() + "/" + crashInfo.getFingerprint(), crashInfo.getThrowable());
+                    Crashlytics.logException(exception);
                 });
             } catch (Throwable t) {
                 Log.w("Problem while initializing AndroidWearCrashReport", t);
@@ -97,13 +93,10 @@ public class Application extends android.app.Application {
 
     private void setupStrictMode() {
         // Do this in a Handler.post because of this issue: http://code.google.com/p/android/issues/detail?id=35298
-        new Handler().post(new Runnable() {
-            @Override
-            public void run() {
-                // Do not detect disk reads/writes because it seems it causes bugs in Google Maps (?!)
-                StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().detectCustomSlowCalls().detectNetwork().penaltyLog().build());
-                StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().detectAll().penaltyLog().build());
-            }
+        new Handler().post(() -> {
+            // Do not detect disk reads/writes because it seems it causes bugs in Google Maps (?!)
+            StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().detectCustomSlowCalls().detectNetwork().penaltyLog().build());
+            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().detectAll().penaltyLog().build());
         });
     }
 

--- a/handheld/src/main/java/org/jraf/android/bikey/app/display/DisplayActivity.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/display/DisplayActivity.java
@@ -38,7 +38,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.View.OnSystemUiVisibilityChangeListener;
 import android.view.View.OnTouchListener;
 import android.view.WindowManager;
 import android.view.animation.AccelerateInterpolator;
@@ -119,15 +118,12 @@ public class DisplayActivity extends BaseFragmentActivity {
     }
 
     private void setupFragmentContainer() {
-        mConFragments.post(new Runnable() {
-            @Override
-            public void run() {
-                PointF shrinkPercents = getShrinkPercents();
-                mConFragments.setScaleX(shrinkPercents.x);
-                mConFragments.setScaleY(shrinkPercents.y);
+        mConFragments.post(() -> {
+            PointF shrinkPercents = getShrinkPercents();
+            mConFragments.setScaleX(shrinkPercents.x);
+            mConFragments.setScaleY(shrinkPercents.y);
 
-                mTxtTitle.setAlpha(0);
-            }
+            mTxtTitle.setAlpha(0);
         });
     }
 
@@ -232,17 +228,14 @@ public class DisplayActivity extends BaseFragmentActivity {
 
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
     private void setupNavigationBarHiding() {
-        findViewById(android.R.id.content).setOnSystemUiVisibilityChangeListener(new OnSystemUiVisibilityChangeListener() {
-            @Override
-            public void onSystemUiVisibilityChange(int visibility) {
-                Log.d("visibility=" + visibility);
-                if ((visibility & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) != View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) {
-                    Log.d("Navigation bar showing");
-                    if (!isPaused()) mFragmentCycler.cycle(thiz);
-                    scheduleHideNavigationBar();
-                    showControls();
-                    scheduleHideControls();
-                }
+        findViewById(android.R.id.content).setOnSystemUiVisibilityChangeListener(visibility -> {
+            Log.d("visibility=" + visibility);
+            if ((visibility & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) != View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) {
+                Log.d("Navigation bar showing");
+                if (!isPaused()) mFragmentCycler.cycle(thiz);
+                scheduleHideNavigationBar();
+                showControls();
+                scheduleHideControls();
             }
         });
         scheduleHideNavigationBar();
@@ -270,12 +263,7 @@ public class DisplayActivity extends BaseFragmentActivity {
         return super.dispatchTouchEvent(ev);
     }
 
-    private Runnable mHideNavigationBarRunnable = new Runnable() {
-        @Override
-        public void run() {
-            hideNavigationBar();
-        }
-    };
+    private Runnable mHideNavigationBarRunnable = this::hideNavigationBar;
 
     private void scheduleHideNavigationBar() {
         mHandler.removeCallbacks(mHideNavigationBarRunnable);
@@ -415,12 +403,7 @@ public class DisplayActivity extends BaseFragmentActivity {
         mTxtTitle.animate().alpha(0).setDuration(duration).setStartDelay(0);
     }
 
-    private Runnable mHideControlsRunnable = new Runnable() {
-        @Override
-        public void run() {
-            hideControls();
-        }
-    };
+    private Runnable mHideControlsRunnable = this::hideControls;
 
     private void scheduleHideControls() {
         mHandler.removeCallbacks(mHideControlsRunnable);

--- a/handheld/src/main/java/org/jraf/android/bikey/app/display/fragment/LogDisplayFragment.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/display/fragment/LogDisplayFragment.java
@@ -107,27 +107,24 @@ public abstract class LogDisplayFragment extends SimpleDisplayFragment {
         }
     };
 
-    private LogListener mLogListener = new LogListener() {
-        @Override
-        public void onLogAdded(final Uri rideUri) {
-            if (!rideUri.equals(getRideUri())) return;
-            if (!isAdded()) return;
+    private LogListener mLogListener = rideUri -> {
+        if (!rideUri.equals(getRideUri())) return;
+        if (!isAdded()) return;
 
-            new AsyncTask<Void, Void, Void>() {
-                private CharSequence mValue;
+        new AsyncTask<Void, Void, Void>() {
+            private CharSequence mValue;
 
-                @Override
-                protected Void doInBackground(Void... params) {
-                    mValue = queryValue();
-                    return null;
-                }
+            @Override
+            protected Void doInBackground(Void... params) {
+                mValue = queryValue();
+                return null;
+            }
 
-                @Override
-                protected void onPostExecute(Void result) {
-                    setText(mValue);
-                }
-            }.execute();
-        }
+            @Override
+            protected void onPostExecute(Void result) {
+                setText(mValue);
+            }
+        }.execute();
     };
 
     @WorkerThread

--- a/handheld/src/main/java/org/jraf/android/bikey/app/display/fragment/cadence/CadenceDisplayFragment.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/display/fragment/cadence/CadenceDisplayFragment.java
@@ -48,13 +48,10 @@ public class CadenceDisplayFragment extends SimpleDisplayFragment {
         super.onStop();
     }
 
-    private CadenceListener mCadenceListener = new CadenceListener() {
-        @Override
-        public void onCadenceChanged(Float cadence, float[][] rawData) {
-            setText(UnitUtil.formatCadence(cadence));
-            setValues(0, rawData[0]);
-            setValues(1, rawData[1]);
-            setValues(2, rawData[2]);
-        }
+    private CadenceListener mCadenceListener = (cadence, rawData) -> {
+        setText(UnitUtil.formatCadence(cadence));
+        setValues(0, rawData[0]);
+        setValues(1, rawData[1]);
+        setValues(2, rawData[2]);
     };
 }

--- a/handheld/src/main/java/org/jraf/android/bikey/app/display/fragment/speed/SpeedDisplayFragment.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/display/fragment/speed/SpeedDisplayFragment.java
@@ -72,10 +72,5 @@ public class SpeedDisplayFragment extends SimpleDisplayFragment {
         }
     };
 
-    private StatusListener mGpsStatusListener = new StatusListener() {
-        @Override
-        public void onStatusChanged(boolean active) {
-            setTextEnabled(active);
-        }
-    };
+    private StatusListener mGpsStatusListener = this::setTextEnabled;
 }

--- a/handheld/src/main/java/org/jraf/android/bikey/app/googledrivesync/GoogleDriveSyncActivity.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/googledrivesync/GoogleDriveSyncActivity.java
@@ -217,12 +217,7 @@ public class GoogleDriveSyncActivity extends BaseAppCompatActivity implements Go
 
     @Override
     public void onDeleteRemoteItemsFinish() {
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                mTxtDeleteRemoteItems.setChecked(true);
-            }
-        });
+        runOnUiThread(() -> mTxtDeleteRemoteItems.setChecked(true));
     }
 
     @Override
@@ -230,12 +225,7 @@ public class GoogleDriveSyncActivity extends BaseAppCompatActivity implements Go
 
     @Override
     public void onDeleteLocalItemsFinish() {
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                mTxtDeleteLocalItems.setChecked(true);
-            }
-        });
+        runOnUiThread(() -> mTxtDeleteLocalItems.setChecked(true));
     }
 
     @Override
@@ -243,23 +233,15 @@ public class GoogleDriveSyncActivity extends BaseAppCompatActivity implements Go
 
     @Override
     public void onUploadNewLocalItemsProgress(final int progress, final int total) {
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                mPgbUploadNewLocalItems.setMax(total);
-                mPgbUploadNewLocalItems.setProgress(progress);
-            }
+        runOnUiThread(() -> {
+            mPgbUploadNewLocalItems.setMax(total);
+            mPgbUploadNewLocalItems.setProgress(progress);
         });
     }
 
     @Override
     public void onUploadNewLocalItemsFinish() {
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                mTxtUploadNewLocalItems.setChecked(true);
-            }
-        });
+        runOnUiThread(() -> mTxtUploadNewLocalItems.setChecked(true));
     }
 
     @Override
@@ -267,33 +249,20 @@ public class GoogleDriveSyncActivity extends BaseAppCompatActivity implements Go
 
     @Override
     public void onDownloadNewRemoteItemsOverallProgress(final int progress, final int total) {
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                mTxtDownloadNewRemoteItems.setText(getString(R.string.googleDriveSync_downloadNewRemoteItems_progress, progress, total));
-            }
-        });
+        runOnUiThread(() -> mTxtDownloadNewRemoteItems.setText(getString(R.string.googleDriveSync_downloadNewRemoteItems_progress, progress, total)));
     }
 
     @Override
     public void onDownloadNewRemoteItemsDownloadProgress(final long progress, final long total) {
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                mPgbDownloadNewRemoteItems.setMax((int) total);
-                mPgbDownloadNewRemoteItems.setProgress((int) progress);
-            }
+        runOnUiThread(() -> {
+            mPgbDownloadNewRemoteItems.setMax((int) total);
+            mPgbDownloadNewRemoteItems.setProgress((int) progress);
         });
     }
 
     @Override
     public void onDownloadNewRemoteItemsFinish() {
-        runOnUiThread(new Runnable() {
-                          @Override
-                          public void run() {
-                              mTxtDownloadNewRemoteItems.setChecked(true);
-                          }
-                      }
+        runOnUiThread(() -> mTxtDownloadNewRemoteItems.setChecked(true)
 
         );
     }
@@ -301,14 +270,11 @@ public class GoogleDriveSyncActivity extends BaseAppCompatActivity implements Go
     @Override
     public void onSyncFinish(final boolean success) {
         Log.d();
-        runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                if (success) {
-                    mTxtSuccess.setVisibility(View.VISIBLE);
-                } else {
-                    mTxtFail.setVisibility(View.VISIBLE);
-                }
+        runOnUiThread(() -> {
+            if (success) {
+                mTxtSuccess.setVisibility(View.VISIBLE);
+            } else {
+                mTxtFail.setVisibility(View.VISIBLE);
             }
         });
     }

--- a/handheld/src/main/java/org/jraf/android/bikey/app/heartrate/bluetooth/BleScanListFragment.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/heartrate/bluetooth/BleScanListFragment.java
@@ -118,15 +118,12 @@ public class BleScanListFragment extends ListFragment {
             }
             mFoundDeviceAddressList.add(device.getAddress());
 
-            HandlerUtil.runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    if (mBleScanListAdapter == null) {
-                        mBleScanListAdapter = new BleScanListAdapter(getActivity());
-                        setListAdapter(mBleScanListAdapter);
-                    }
-                    mBleScanListAdapter.add(device);
+            HandlerUtil.runOnUiThread(() -> {
+                if (mBleScanListAdapter == null) {
+                    mBleScanListAdapter = new BleScanListAdapter(getActivity());
+                    setListAdapter(mBleScanListAdapter);
                 }
+                mBleScanListAdapter.add(device);
             });
         }
     };

--- a/handheld/src/main/java/org/jraf/android/bikey/app/preference/MainPreferenceFragment.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/preference/MainPreferenceFragment.java
@@ -27,7 +27,6 @@ package org.jraf.android.bikey.app.preference;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -123,41 +122,38 @@ public class MainPreferenceFragment extends PreferenceFragment {
         super.onStop();
     }
 
-    private final OnSharedPreferenceChangeListener mOnSharedPreferenceChangeListener = new OnSharedPreferenceChangeListener() {
-        @Override
-        public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-            updateListPreferenceSummary(key);
-            switch (key) {
-                case Constants.PREF_UNITS:
-                    // Update units
-                    UnitUtil.readPreferences(getActivity());
+    private final OnSharedPreferenceChangeListener mOnSharedPreferenceChangeListener = (sharedPreferences, key) -> {
+        updateListPreferenceSummary(key);
+        switch (key) {
+            case Constants.PREF_UNITS:
+                // Update units
+                UnitUtil.readPreferences(getActivity());
 
-                    // Propagate unit preferences to wearables
-                    WearCommHelper.get().updatePreferences();
+                // Propagate unit preferences to wearables
+                WearCommHelper.get().updatePreferences();
 
-                    // Notify observers of rides since they display distances using a conversion depending on the preference
-                    getActivity().getContentResolver().notifyChange(RideColumns.CONTENT_URI, null);
-                    break;
+                // Notify observers of rides since they display distances using a conversion depending on the preference
+                getActivity().getContentResolver().notifyChange(RideColumns.CONTENT_URI, null);
+                break;
 
-                case Constants.PREF_LISTEN_TO_HEADSET_BUTTON:
-                    if (sharedPreferences.getBoolean(key, Constants.PREF_LISTEN_TO_HEADSET_BUTTON_DEFAULT)) {
-                        MediaButtonUtil.registerMediaButtonEventReceiver(getActivity());
-                    } else {
-                        MediaButtonUtil.unregisterMediaButtonEventReceiver();
-                    }
-                    break;
+            case Constants.PREF_LISTEN_TO_HEADSET_BUTTON:
+                if (sharedPreferences.getBoolean(key, Constants.PREF_LISTEN_TO_HEADSET_BUTTON_DEFAULT)) {
+                    MediaButtonUtil.registerMediaButtonEventReceiver(getActivity());
+                } else {
+                    MediaButtonUtil.unregisterMediaButtonEventReceiver();
+                }
+                break;
 
-                case Constants.PREF_RECORD_CADENCE:
-                    if (sharedPreferences.getBoolean(Constants.PREF_RECORD_CADENCE, Constants.PREF_RECORD_CADENCE_DEFAULT)) {
-                        getCallbacks().showRecordCadenceConfirmDialog();
-                    } else {
-                        // The pref was unchecked because the user pressed 'No' in the confirmation dialog.
-                        // Update the switch.
-                        SwitchPreference pref = (SwitchPreference) getPreferenceManager().findPreference(Constants.PREF_RECORD_CADENCE);
-                        pref.setChecked(false);
-                    }
-                    break;
-            }
+            case Constants.PREF_RECORD_CADENCE:
+                if (sharedPreferences.getBoolean(Constants.PREF_RECORD_CADENCE, Constants.PREF_RECORD_CADENCE_DEFAULT)) {
+                    getCallbacks().showRecordCadenceConfirmDialog();
+                } else {
+                    // The pref was unchecked because the user pressed 'No' in the confirmation dialog.
+                    // Update the switch.
+                    SwitchPreference pref = (SwitchPreference) getPreferenceManager().findPreference(Constants.PREF_RECORD_CADENCE);
+                    pref.setChecked(false);
+                }
+                break;
         }
     };
 
@@ -169,31 +165,28 @@ public class MainPreferenceFragment extends PreferenceFragment {
         }
     }
 
-    private OnPreferenceClickListener mOnPreferenceClickListener = new OnPreferenceClickListener() {
-        @Override
-        public boolean onPreferenceClick(Preference preference) {
-            if (Constants.PREF_EXPORT.equals(preference.getKey())) {
-                getCallbacks().startExport();
-                return true;
-            } else if (Constants.PREF_IMPORT.equals(preference.getKey())) {
-                getCallbacks().startImport();
-                return true;
-            } else if (Constants.SYNC_WITH_GOOGLE_DRIVE.equals(preference.getKey())) {
-                getCallbacks().syncWithGoogleDrive();
-                return true;
-            } else if (Constants.PREF_HEART_RATE_SCAN.equals(preference.getKey())) {
-                HeartRateManager heartRateManager = HeartRateManager.get();
-                if (heartRateManager.isConnected()) {
-                    getCallbacks().disconnectHeartRateMonitor();
-                } else if (heartRateManager.isConnecting()) {
-                    getCallbacks().tryToReconnectHeartRateMonitorOrGiveUp();
-                } else {
-                    getCallbacks().startHeartRateMonitorScan();
-                }
-                return true;
+    private OnPreferenceClickListener mOnPreferenceClickListener = preference -> {
+        if (Constants.PREF_EXPORT.equals(preference.getKey())) {
+            getCallbacks().startExport();
+            return true;
+        } else if (Constants.PREF_IMPORT.equals(preference.getKey())) {
+            getCallbacks().startImport();
+            return true;
+        } else if (Constants.SYNC_WITH_GOOGLE_DRIVE.equals(preference.getKey())) {
+            getCallbacks().syncWithGoogleDrive();
+            return true;
+        } else if (Constants.PREF_HEART_RATE_SCAN.equals(preference.getKey())) {
+            HeartRateManager heartRateManager = HeartRateManager.get();
+            if (heartRateManager.isConnected()) {
+                getCallbacks().disconnectHeartRateMonitor();
+            } else if (heartRateManager.isConnecting()) {
+                getCallbacks().tryToReconnectHeartRateMonitorOrGiveUp();
+            } else {
+                getCallbacks().startHeartRateMonitorScan();
             }
-            return false;
+            return true;
         }
+        return false;
     };
 
     private HeartRateListener mHeartRateListener = new HeartRateListener() {

--- a/handheld/src/main/java/org/jraf/android/bikey/app/ride/detail/RideDetailActivity.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/ride/detail/RideDetailActivity.java
@@ -70,7 +70,6 @@ import org.jraf.android.util.ui.graph.GraphView;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.LatLng;
@@ -407,22 +406,16 @@ public class RideDetailActivity extends BaseAppCompatActivity implements AlertDi
     private GoogleMap getMap() {
         if (mMap == null) {
             final CountDownLatch latch = new CountDownLatch(1);
-            HandlerUtil.runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
-                    if (mapFragment == null) {
-                        latch.countDown();
-                        return;
-                    }
-                    mapFragment.getMapAsync(new OnMapReadyCallback() {
-                        @Override
-                        public void onMapReady(GoogleMap googleMap) {
-                            mMap = googleMap;
-                            latch.countDown();
-                        }
-                    });
+            HandlerUtil.runOnUiThread(() -> {
+                SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
+                if (mapFragment == null) {
+                    latch.countDown();
+                    return;
                 }
+                mapFragment.getMapAsync(googleMap -> {
+                    mMap = googleMap;
+                    latch.countDown();
+                });
             });
 
             try {

--- a/handheld/src/main/java/org/jraf/android/bikey/app/ride/edit/RideEditActivity.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/ride/edit/RideEditActivity.java
@@ -28,13 +28,9 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
-import android.view.KeyEvent;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.EditText;
-import android.widget.TextView;
-import android.widget.TextView.OnEditorActionListener;
 
 import org.jraf.android.bikey.R;
 import org.jraf.android.bikey.backend.ride.RideManager;
@@ -50,12 +46,9 @@ public class RideEditActivity extends BaseAppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.ride_edit);
         mEdtName = (EditText) findViewById(R.id.edtName);
-        mEdtName.setOnEditorActionListener(new OnEditorActionListener() {
-            @Override
-            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-                saveRide();
-                return true;
-            }
+        mEdtName.setOnEditorActionListener((v, actionId, event) -> {
+            saveRide();
+            return true;
         });
         populateViews();
         setupActionBar();
@@ -86,20 +79,10 @@ public class RideEditActivity extends BaseAppCompatActivity {
         actionBar.setCustomView(customActionBarView, new ActionBar.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
         View btnDone = customActionBarView.findViewById(R.id.actionbar_done);
-        btnDone.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                saveRide();
-            }
-        });
+        btnDone.setOnClickListener(v -> saveRide());
 
         View btnDiscard = customActionBarView.findViewById(R.id.actionbar_discard);
-        btnDiscard.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                finish();
-            }
-        });
+        btnDiscard.setOnClickListener(v -> finish());
     }
 
     private void saveRide() {

--- a/handheld/src/main/java/org/jraf/android/bikey/app/ride/list/RideListActivity.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/ride/list/RideListActivity.java
@@ -31,8 +31,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
-import android.view.View.OnClickListener;
 
 import org.jraf.android.bikey.BuildConfig;
 import org.jraf.android.bikey.R;
@@ -73,12 +71,7 @@ public class RideListActivity extends BaseAppCompatActivity implements AlertDial
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.ride_list);
-        findViewById(R.id.btnQuickStart).setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                quickStart();
-            }
-        });
+        findViewById(R.id.btnQuickStart).setOnClickListener(v -> quickStart());
         restoreState();
 
         MediaButtonUtil.registerMediaButtonEventReceiverAccordingToPreferences(this);

--- a/handheld/src/main/java/org/jraf/android/bikey/app/ride/map/RideMapActivity.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/app/ride/map/RideMapActivity.java
@@ -53,7 +53,6 @@ import org.jraf.android.util.handler.HandlerUtil;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.LatLng;
@@ -274,18 +273,12 @@ public class RideMapActivity extends BaseAppCompatActivity {
     private GoogleMap getMap() {
         if (mMap == null) {
             final CountDownLatch latch = new CountDownLatch(1);
-            HandlerUtil.runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                    SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
-                    mapFragment.getMapAsync(new OnMapReadyCallback() {
-                        @Override
-                        public void onMapReady(GoogleMap googleMap) {
-                            mMap = googleMap;
-                            latch.countDown();
-                        }
-                    });
-                }
+            HandlerUtil.runOnUiThread(() -> {
+                SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
+                mapFragment.getMapAsync(googleMap -> {
+                    mMap = googleMap;
+                    latch.countDown();
+                });
             });
 
             try {

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/cadence/CadenceManager.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/cadence/CadenceManager.java
@@ -38,7 +38,6 @@ import android.hardware.SensorManager;
 
 import org.jraf.android.bikey.app.Application;
 import org.jraf.android.util.listeners.Listeners;
-import org.jraf.android.util.listeners.Listeners.Dispatcher;
 import org.jraf.android.util.log.Log;
 import org.jraf.android.util.math.MathUtil;
 import org.jraf.android.util.object.ObjectUtil;
@@ -69,7 +68,7 @@ public class CadenceManager {
     }
 
     private Context mContext;
-    private ArrayDeque<Entry> mValues = new ArrayDeque<Entry>(200);
+    private ArrayDeque<Entry> mValues = new ArrayDeque<>(200);
     private ScheduledExecutorService mScheduledExecutorService;
     protected Float mLastValue = -1f;
     private float[][] mLastRawData;
@@ -217,7 +216,7 @@ public class CadenceManager {
 
         // Average
         float average = MathUtil.getAverage(values);
-        ArrayList<Long> periods = new ArrayList<Long>();
+        ArrayList<Long> periods = new ArrayList<>();
         long lastTime = -1;
         for (int i = 1; i < len; i++) {
             if (values[i - 1] < average && values[i] >= average) {
@@ -265,12 +264,7 @@ public class CadenceManager {
                 return;
             }
             mLastValue = value;
-            mListeners.dispatch(new Dispatcher<CadenceListener>() {
-                @Override
-                public void dispatch(CadenceListener listener) {
-                    listener.onCadenceChanged(value, mLastRawData);
-                }
-            });
+            mListeners.dispatch(listener -> listener.onCadenceChanged(value, mLastRawData));
         }
     };
 }

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/compass/CompassManager.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/compass/CompassManager.java
@@ -32,7 +32,6 @@ import android.hardware.SensorManager;
 
 import org.jraf.android.bikey.app.Application;
 import org.jraf.android.util.listeners.Listeners;
-import org.jraf.android.util.listeners.Listeners.Dispatcher;
 import org.jraf.android.util.log.Log;
 
 public class CompassManager {
@@ -118,12 +117,7 @@ public class CompassManager {
                 float azimuth = deviceOrientation[0];
                 final float value = 1f - (float) (azimuth / (2 * Math.PI));
 
-                mListeners.dispatch(new Dispatcher<CompassListener>() {
-                    @Override
-                    public void dispatch(CompassListener listener) {
-                        listener.onCompassChange(value);
-                    }
-                });
+                mListeners.dispatch(listener -> listener.onCompassChange(value));
             }
         }
 

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/dbimport/DatabaseImporter.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/dbimport/DatabaseImporter.java
@@ -80,7 +80,7 @@ public class DatabaseImporter {
     private static void importDatabase(Context context, File importDb) throws RemoteException, OperationApplicationException {
         Log.d("importDb=" + importDb);
         SQLiteDatabase dbImport = SQLiteDatabase.openDatabase(importDb.getAbsolutePath(), null, SQLiteDatabase.OPEN_READONLY);
-        ArrayList<ContentProviderOperation> operations = new ArrayList<ContentProviderOperation>();
+        ArrayList<ContentProviderOperation> operations = new ArrayList<>();
         operations.add(ContentProviderOperation.newDelete(LogColumns.CONTENT_URI).build());
         operations.add(ContentProviderOperation.newDelete(RideColumns.CONTENT_URI).build());
         Uri insertUri = new Uri.Builder().authority(BikeyProvider.AUTHORITY).appendPath(RideColumns.TABLE_NAME)

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/googledrive/GoogleDriveSyncManager.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/googledrive/GoogleDriveSyncManager.java
@@ -424,12 +424,7 @@ public class GoogleDriveSyncManager {
             Log.d("Download " + serverItem);
             DriveFile driveFile = Drive.DriveApi.getFile(googleApiClient, serverItem.driveId);
             DriveApi.DriveContentsResult driveContentsResult =
-                    driveFile.open(googleApiClient, DriveFile.MODE_READ_ONLY, new DriveFile.DownloadProgressListener() {
-                        @Override
-                        public void onProgress(long bytesDownloaded, long bytesExpected) {
-                            Log.d(bytesDownloaded + "/" + bytesExpected);
-                        }
-                    }).await(AWAIT_DELAY_LONG, AWAIT_UNIT_LONG);
+                    driveFile.open(googleApiClient, DriveFile.MODE_READ_ONLY, (bytesDownloaded, bytesExpected) -> Log.d(bytesDownloaded + "/" + bytesExpected)).await(AWAIT_DELAY_LONG, AWAIT_UNIT_LONG);
             Status status = driveContentsResult.getStatus();
             Log.d("driveContentsResult.status=" + status);
             if (!status.isSuccess()) {

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/heartrate/HeartRateManagerJellyBeanMR2.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/heartrate/HeartRateManagerJellyBeanMR2.java
@@ -40,7 +40,6 @@ import android.os.Build;
 
 import org.jraf.android.bikey.app.Application;
 import org.jraf.android.util.listeners.Listeners;
-import org.jraf.android.util.listeners.Listeners.Dispatcher;
 import org.jraf.android.util.log.Log;
 import org.jraf.android.util.log.LogUtil;
 
@@ -91,12 +90,7 @@ public class HeartRateManagerJellyBeanMR2 extends HeartRateManager {
         Log.d();
         mStatus = Status.CONNECTING;
         // Inform listeners
-        mListeners.dispatch(new Dispatcher<HeartRateListener>() {
-            @Override
-            public void dispatch(HeartRateListener listener) {
-                listener.onConnecting();
-            }
-        });
+        mListeners.dispatch(HeartRateListener::onConnecting);
 
         mBluetoothDevice = bluetoothDevice;
         mBluetoothGatt = mBluetoothDevice.connectGatt(mContext, true, mBluetoothGattCallback);
@@ -168,22 +162,12 @@ public class HeartRateManagerJellyBeanMR2 extends HeartRateManager {
                 mStatus = Status.CONNECTED;
 
                 // Inform listeners
-                mListeners.dispatch(new Dispatcher<HeartRateListener>() {
-                    @Override
-                    public void dispatch(HeartRateListener listener) {
-                        listener.onConnected();
-                    }
-                });
+                mListeners.dispatch(HeartRateListener::onConnected);
             }
 
             if (previousValue != mLastValue) {
                 // Inform listeners
-                mListeners.dispatch(new Dispatcher<HeartRateListener>() {
-                    @Override
-                    public void dispatch(HeartRateListener listener) {
-                        listener.onHeartRateChange(mLastValue);
-                    }
-                });
+                mListeners.dispatch(listener -> listener.onHeartRateChange(mLastValue));
             }
         }
     };
@@ -191,12 +175,7 @@ public class HeartRateManagerJellyBeanMR2 extends HeartRateManager {
     private void onDisconnect() {
         mStatus = Status.DISCONNECTED;
         mLastValue = -1;
-        mListeners.dispatch(new Dispatcher<HeartRateListener>() {
-            @Override
-            public void dispatch(HeartRateListener listener) {
-                listener.onDisconnected();
-            }
-        });
+        mListeners.dispatch(HeartRateListener::onDisconnected);
     }
 
 
@@ -227,12 +206,7 @@ public class HeartRateManagerJellyBeanMR2 extends HeartRateManager {
     }
 
     private void onError() {
-        mListeners.dispatch(new Dispatcher<HeartRateListener>() {
-            @Override
-            public void dispatch(HeartRateListener listener) {
-                listener.onError();
-            }
-        });
+        mListeners.dispatch(HeartRateListener::onError);
     }
 
 

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/location/LocationManager.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/location/LocationManager.java
@@ -33,7 +33,6 @@ import android.os.Handler;
 import org.jraf.android.bikey.app.Application;
 import org.jraf.android.util.handler.HandlerUtil;
 import org.jraf.android.util.listeners.Listeners;
-import org.jraf.android.util.listeners.Listeners.Dispatcher;
 import org.jraf.android.util.log.Log;
 
 public class LocationManager {
@@ -104,24 +103,18 @@ public class LocationManager {
     private void startLocationListener() {
         Log.d();
         mIgnoreLocationCount = IGNORE_LOCATION_COUNT;
-        HandlerUtil.getMainHandler().post(new Runnable() {
-            @Override
-            public void run() {
-                android.location.LocationManager locationManager = (android.location.LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
-                locationManager.removeUpdates(mGpsLocationListener);
-                locationManager.requestLocationUpdates(android.location.LocationManager.GPS_PROVIDER, INTERVAL_LOC_REQUEST, 0, mGpsLocationListener);
-            }
+        HandlerUtil.getMainHandler().post(() -> {
+            android.location.LocationManager locationManager = (android.location.LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
+            locationManager.removeUpdates(mGpsLocationListener);
+            locationManager.requestLocationUpdates(android.location.LocationManager.GPS_PROVIDER, INTERVAL_LOC_REQUEST, 0, mGpsLocationListener);
         });
     }
 
     private void stopLocationListener() {
         Log.d();
-        HandlerUtil.getMainHandler().post(new Runnable() {
-            @Override
-            public void run() {
-                android.location.LocationManager locationManager = (android.location.LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
-                locationManager.removeUpdates(mGpsLocationListener);
-            }
+        HandlerUtil.getMainHandler().post(() -> {
+            android.location.LocationManager locationManager = (android.location.LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
+            locationManager.removeUpdates(mGpsLocationListener);
         });
     }
 
@@ -166,12 +159,7 @@ public class LocationManager {
             }
 
             // Dispatch to listeners
-            mLocationListeners.dispatch(new Dispatcher<LocationListener>() {
-                @Override
-                public void dispatch(LocationListener listener) {
-                    listener.onLocationChanged(location);
-                }
-            });
+            mLocationListeners.dispatch(listener -> listener.onLocationChanged(location));
         }
 
         @Override
@@ -214,24 +202,18 @@ public class LocationManager {
     private void startGpsLocationListener() {
         Log.d();
         setActive(false);
-        HandlerUtil.getMainHandler().post(new Runnable() {
-            @Override
-            public void run() {
-                android.location.LocationManager locationManager = (android.location.LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
-                locationManager.removeUpdates(mGpsStatusLocationListener);
-                locationManager.requestLocationUpdates(android.location.LocationManager.GPS_PROVIDER, INTERVAL_LOC_REQUEST, 0, mGpsStatusLocationListener);
-            }
+        HandlerUtil.getMainHandler().post(() -> {
+            android.location.LocationManager locationManager = (android.location.LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
+            locationManager.removeUpdates(mGpsStatusLocationListener);
+            locationManager.requestLocationUpdates(android.location.LocationManager.GPS_PROVIDER, INTERVAL_LOC_REQUEST, 0, mGpsStatusLocationListener);
         });
     }
 
     private void stopGpsLocationListener() {
         Log.d();
-        HandlerUtil.getMainHandler().post(new Runnable() {
-            @Override
-            public void run() {
-                android.location.LocationManager locationManager = (android.location.LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
-                locationManager.removeUpdates(mGpsStatusLocationListener);
-            }
+        HandlerUtil.getMainHandler().post(() -> {
+            android.location.LocationManager locationManager = (android.location.LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
+            locationManager.removeUpdates(mGpsStatusLocationListener);
         });
     }
 
@@ -282,12 +264,7 @@ public class LocationManager {
     protected void setActive(final boolean active) {
         if (mActive != active) {
             // Dispatch to listeners
-            mStatusListeners.dispatch(new Dispatcher<StatusListener>() {
-                @Override
-                public void dispatch(StatusListener listener) {
-                    listener.onStatusChanged(active);
-                }
-            });
+            mStatusListeners.dispatch(listener -> listener.onStatusChanged(active));
         }
         mActive = active;
     }

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/location/Speedometer.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/location/Speedometer.java
@@ -67,7 +67,7 @@ public class Speedometer implements LocationListener {
     }
 
     private Location mLastLocation = null;
-    private Deque<LocationPair> mLog = new ArrayDeque<LocationPair>(LOG_SIZE_MAX);
+    private Deque<LocationPair> mLog = new ArrayDeque<>(LOG_SIZE_MAX);
     private int mLogSize = LOG_SIZE_SLOW;
     public DebugInfo mDebugInfo = new DebugInfo();
 

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/log/LogManager.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/log/LogManager.java
@@ -44,7 +44,6 @@ import org.jraf.android.bikey.backend.provider.log.LogCursor;
 import org.jraf.android.bikey.backend.provider.log.LogSelection;
 import org.jraf.android.bikey.backend.ride.RideManager;
 import org.jraf.android.util.listeners.Listeners;
-import org.jraf.android.util.listeners.Listeners.Dispatcher;
 import org.jraf.android.util.log.Log;
 
 import com.google.android.gms.maps.model.LatLng;
@@ -94,12 +93,7 @@ public class LogManager {
         RideManager.get().updateTotalDistance(rideUri, totalDistance);
 
         // Dispatch to listeners
-        mListeners.dispatch(new Dispatcher<LogListener>() {
-            @Override
-            public void dispatch(LogListener listener) {
-                listener.onLogAdded(rideUri);
-            }
-        });
+        mListeners.dispatch(listener -> listener.onLogAdded(rideUri));
         return res;
     }
 

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/provider/BikeyProvider.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/provider/BikeyProvider.java
@@ -31,7 +31,6 @@ import android.content.UriMatcher;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.net.Uri;
-import android.support.annotation.NonNull;
 import android.util.Log;
 
 import org.jraf.android.bikey.BuildConfig;

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/provider/base/AbstractCursor.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/provider/base/AbstractCursor.java
@@ -29,14 +29,13 @@ import java.util.HashMap;
 
 import android.database.Cursor;
 import android.database.CursorWrapper;
-import android.provider.BaseColumns;
 
 public abstract class AbstractCursor extends CursorWrapper {
     private final HashMap<String, Integer> mColumnIndexes;
 
     public AbstractCursor(Cursor cursor) {
         super(cursor);
-        mColumnIndexes = new HashMap<String, Integer>(cursor.getColumnCount() * 4 / 3, .75f);
+        mColumnIndexes = new HashMap<>(cursor.getColumnCount() * 4 / 3, .75f);
     }
 
     public abstract long getId();

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/provider/base/AbstractSelection.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/provider/base/AbstractSelection.java
@@ -54,7 +54,7 @@ public abstract class AbstractSelection<T extends AbstractSelection<?>> {
     private static final String ENDS = " LIKE '%' || ?";
 
     private final StringBuilder mSelection = new StringBuilder();
-    private final List<String> mSelectionArgs = new ArrayList<String>(5);
+    private final List<String> mSelectionArgs = new ArrayList<>(5);
 
     Boolean mNotify;
     String mGroupBy;

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/provider/base/BaseContentProvider.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/provider/base/BaseContentProvider.java
@@ -38,7 +38,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.net.Uri;
 import android.provider.BaseColumns;
-import android.support.annotation.NonNull;
 import android.util.Log;
 
 public abstract class BaseContentProvider extends ContentProvider {
@@ -174,7 +173,7 @@ public abstract class BaseContentProvider extends ContentProvider {
 
     @Override
     public ContentProviderResult[] applyBatch(ArrayList<ContentProviderOperation> operations) throws OperationApplicationException {
-        HashSet<Uri> urisToNotify = new HashSet<Uri>(operations.size());
+        HashSet<Uri> urisToNotify = new HashSet<>(operations.size());
         for (ContentProviderOperation operation : operations) {
             urisToNotify.add(operation.getUri());
         }

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/provider/log/LogColumns.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/provider/log/LogColumns.java
@@ -28,7 +28,6 @@ import android.net.Uri;
 import android.provider.BaseColumns;
 
 import org.jraf.android.bikey.backend.provider.BikeyProvider;
-import org.jraf.android.bikey.backend.provider.log.LogColumns;
 import org.jraf.android.bikey.backend.provider.ride.RideColumns;
 
 /**

--- a/handheld/src/main/java/org/jraf/android/bikey/backend/ride/RideManager.java
+++ b/handheld/src/main/java/org/jraf/android/bikey/backend/ride/RideManager.java
@@ -54,7 +54,6 @@ import org.jraf.android.bikey.backend.provider.ride.RideSelection;
 import org.jraf.android.bikey.backend.provider.ride.RideState;
 import org.jraf.android.bikey.common.Constants;
 import org.jraf.android.util.listeners.Listeners;
-import org.jraf.android.util.listeners.Listeners.Dispatcher;
 import org.jraf.android.util.log.Log;
 
 public class RideManager {
@@ -217,12 +216,7 @@ public class RideManager {
         mContext.getContentResolver().update(rideUri, values.values(), null, null);
 
         // Dispatch to listeners
-        mListeners.dispatch(new Dispatcher<RideListener>() {
-            @Override
-            public void dispatch(RideListener listener) {
-                listener.onActivated(rideUri);
-            }
-        });
+        mListeners.dispatch(listener -> listener.onActivated(rideUri));
     }
 
     @WorkerThread
@@ -273,12 +267,7 @@ public class RideManager {
             mContext.getContentResolver().update(rideUri, values.values(), null, null);
 
             // Dispatch to listeners
-            mListeners.dispatch(new Dispatcher<RideListener>() {
-                @Override
-                public void dispatch(RideListener listener) {
-                    listener.onPaused(rideUri);
-                }
-            });
+            mListeners.dispatch(listener -> listener.onPaused(rideUri));
         } finally {
             c.close();
         }


### PR DESCRIPTION
Used Android Studio to:
* bulk migrate lambdas
* fix unused imports
* fix diamond instantiation of generic objects: `new ArrayList<>();` instead of `new ArrayList<String>();`

Replacing anonymous inner classes with lambdas introduces lots of whitespace (indentation) changes.  To review the real changes ignoring whitespace, see this url: https://github.com/BoD/bikey/pull/40/files?w=1

```
Total methods in handheld-debug.apk: 56866 (86.77% used)
Total fields in handheld-debug.apk:  26849 (40.97% used)
Methods remaining in handheld-debug.apk: 8669
Fields remaining in handheld-debug.apk:  38686
```

This adds 54 methods